### PR TITLE
feat: GitHubリリース作成のためのトークン設定を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,8 @@ jobs:
     - name: Create Release
       if: steps.check_tag.outputs.tag_exists == 'false'
       uses: softprops/action-gh-release@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ steps.get_version.outputs.version }}
         name: Release ${{ steps.get_version.outputs.version }}
         body: |
@@ -108,10 +107,11 @@ jobs:
           *.vsix
     
     # オプション: VS Code マーケットプレースに自動公開 (タグのプッシュ時のみ)
-    # 注: マーケットプレースへの公開準備ができたら以下のステップをコメント解除してください
-    # - name: Publish to VS Code Marketplace
-    #   if: startsWith(github.ref, 'refs/tags/v')
-    #   run: npx @vscode/vsce publish --packagePath $(ls *.vsix)
-    #   env:
-    #     VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+    # 注: マーケットプレースへの公開準備ができたら以下を使用してください
+    - name: Publish to VS Code Marketplace
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: npx @vscode/vsce publish --packagePath $(ls *.vsix)
+      env:
+        VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+      continue-on-error: true
     #   continue-on-error: true


### PR DESCRIPTION
- GITHUB_TOKENの設定をenvからwithに移動
- VS Codeマーケットプレースへの公開ステップをコメント解除し、実行可能に変更