### PR TITLE
feat: リリースノート生成機能を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,25 @@ jobs:
         npm install
         npm ci
     
+    - name: Update CHANGELOG
+      run: |
+        # リポジトリ情報を設定
+        git config --global user.name "GitHub Actions Bot"
+        git config --global user.email "actions@github.com"
+        
+        # CHANGELOGを更新
+        npm run changelog
+        
+        # CHANGELOGが更新されたかチェック
+        if [[ -n $(git status --porcelain CHANGELOG.md) ]]; then
+          echo "CHANGELOG.md was updated, committing changes"
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG.md for v$(node -p "require('./package.json').version")"
+          git push
+        else
+          echo "No changes to CHANGELOG.md"
+        fi
+    
     - name: Run linter
       run: npm run lint
     
@@ -78,6 +97,26 @@ jobs:
         else
           echo "tag_exists=false" >> $GITHUB_OUTPUT
         fi
+        
+    - name: Generate release notes
+      id: release_notes
+      run: |
+        # CHANGELOGからリリースノートを抽出
+        if [ -f "CHANGELOG.md" ]; then
+          CHANGELOG_CONTENT=$(sed -n "/## ${{ steps.get_version.outputs.version }}/,/## /p" CHANGELOG.md | sed '1d;$d')
+          if [ -n "$CHANGELOG_CONTENT" ]; then
+            echo "changelog<<EOF" >> $GITHUB_OUTPUT
+            echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "Extracted release notes from CHANGELOG.md"
+          fi
+        fi
+        
+        # 最近のコミットからリリースノートを生成
+        echo "commits<<EOF" >> $GITHUB_OUTPUT
+        git log -n 10 --pretty=format:"- %s" | grep -v "Merge" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        echo "Generated release notes from recent commits"
     
     - name: Create Release
       if: steps.check_tag.outputs.tag_exists == 'false'
@@ -85,15 +124,12 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ steps.get_version.outputs.version }}
-        name: Release ${{ steps.get_version.outputs.version }}
+        name: Docusaurus Editor ${{ steps.get_version.outputs.version }}
         body: |
           ## Docusaurus Editor ${{ steps.get_version.outputs.version }}
           
-          ### 新機能・改善
-          - 最新の変更内容をここに記載してください
-          
-          ### バグ修正
-          - 修正されたバグをここに記載してください
+          ### 最近の変更
+          ${{ steps.release_notes.outputs.changelog || steps.release_notes.outputs.commits }}
           
           ### インストール方法
           1. リリースから `.vsix` ファイルをダウンロード

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
-# Change Log
+# 変更履歴
 
-All notable changes to the "docusaurus-editor" extension will be documented in this file.
+## v0.0.1 (2025-07-03)
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+### 新機能・改善
+- Docusaurusドキュメントのツリービュー表示機能
+- ドラッグ&ドロップによるドキュメント順序の変更とsidebar_positionの自動更新
+- Markdownフロントマターのサポート
+- 画像フォルダ・画像ファイルの右クリック削除機能
+- 外部アイコンテーマ対応
 
-## [Unreleased]
+### バグ修正
+- 仮想「Images」フォルダを廃止し、実体フォルダ名＋画像数で表示するよう修正
+- CI/CDプロセスの安定化（npm install→npm ciの2段階インストール）
+- GitHubリリース作成の権限エラー修正
 
-- Initial release
+### リファクタリング
+- Webpackによるバンドル設定の最適化
+- 不要ファイル除外設定の拡張
+- GitHubワークフローの改善（テスト・リリースプロセス）

--- a/package.json
+++ b/package.json
@@ -394,7 +394,8 @@
     "webpack": "webpack --mode development",
     "webpack-dev": "webpack --mode development --watch",
     "release": "vsce package",
-    "release:publish": "vsce publish"
+    "release:publish": "vsce publish",
+    "changelog": "node scripts/update-changelog.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -1,0 +1,136 @@
+/**
+ * CHANGELOGを自動的に更新するスクリプト
+ * 
+ * 使用方法:
+ * - npm run changelog [-- --type=<feature|bugfix|refactor> --message="変更内容"]
+ * - デフォルトではfeatureタイプになります
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { version } = require('../package.json');
+
+const CHANGELOG_PATH = path.join(__dirname, '..', 'CHANGELOG.md');
+const DEFAULT_TYPE = 'feature';
+const VALID_TYPES = ['feature', 'bugfix', 'refactor'];
+
+// コマンドライン引数の処理
+function parseArguments() {
+  const args = process.argv.slice(2);
+  const result = { type: DEFAULT_TYPE, message: null };
+  
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--type=')) {
+      const type = args[i].substring(7);
+      if (VALID_TYPES.includes(type)) {
+        result.type = type;
+      }
+    } else if (args[i].startsWith('--message=')) {
+      result.message = args[i].substring(10);
+    }
+  }
+  
+  return result;
+}
+
+// 最近のコミットからメッセージを取得
+function getRecentCommits(count = 5) {
+  try {
+    const output = execSync(`git log -n ${count} --pretty=format:"%s"`)
+      .toString()
+      .split('\n')
+      .filter(line => !line.includes('Merge '));
+    return output;
+  } catch (error) {
+    console.warn('警告: Gitコマンドの実行に失敗しました。', error.message);
+    return [];
+  }
+}
+
+// CHANGELOGに新しいバージョンエントリを追加
+function updateChangelog(type, message) {
+  // CHANGELOGが存在しない場合は新規作成
+  if (!fs.existsSync(CHANGELOG_PATH)) {
+    fs.writeFileSync(CHANGELOG_PATH, '# 変更履歴\n\n');
+  }
+  
+  // 既存のCHANGELOGを読み込む
+  let content = fs.readFileSync(CHANGELOG_PATH, 'utf8');
+  
+  // 現在の日付を取得
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0];
+  
+  // 新しいバージョンセクションを作成
+  let newVersionHeader = `## v${version} (${dateStr})\n\n`;
+  
+  // 変更タイプに基づいてメッセージを追加
+  let changeEntry = '';
+  if (type === 'feature') {
+    changeEntry = '### 新機能・改善\n';
+  } else if (type === 'bugfix') {
+    changeEntry = '### バグ修正\n';
+  } else if (type === 'refactor') {
+    changeEntry = '### リファクタリング\n';
+  }
+  
+  // メッセージが提供されている場合はそれを使用、そうでなければ最近のコミットを使用
+  if (message) {
+    changeEntry += `- ${message}\n\n`;
+  } else {
+    const commits = getRecentCommits();
+    if (commits.length > 0) {
+      commits.forEach(commit => {
+        changeEntry += `- ${commit}\n`;
+      });
+      changeEntry += '\n';
+    } else {
+      changeEntry += '- 詳細は追加されていません\n\n';
+    }
+  }
+  
+  // バージョンがCHANGELOGに既に存在するかチェック
+  if (content.includes(`## v${version}`)) {
+    // バージョンセクションを見つけてエントリを追加
+    const versionRegex = new RegExp(`## v${version}.*?(\n##|$)`, 's');
+    const versionSection = content.match(versionRegex);
+    
+    if (versionSection) {
+      // 変更タイプセクションが既に存在するかチェック
+      const typeSection = changeEntry.split('\n')[0];
+      if (versionSection[0].includes(typeSection)) {
+        // タイプセクションが存在する場合、そこにエントリを追加
+        const typeSectionRegex = new RegExp(`${typeSection}.*?(\n###|$)`, 's');
+        const typeSectionMatch = versionSection[0].match(typeSectionRegex);
+        
+        if (typeSectionMatch) {
+          const updatedTypeSection = typeSectionMatch[0] + '- ' + 
+            (message || getRecentCommits(1)[0] || '詳細は追加されていません') + '\n';
+          content = content.replace(typeSectionMatch[0], updatedTypeSection);
+        }
+      } else {
+        // タイプセクションが存在しない場合、バージョンセクションに追加
+        const updatedVersionSection = versionSection[0].replace(/\n##/, '\n' + changeEntry + '##');
+        content = content.replace(versionSection[0], updatedVersionSection);
+      }
+    }
+  } else {
+    // バージョンが存在しない場合、新しいバージョンセクションを先頭に追加
+    const firstVersionMatch = content.match(/# 変更履歴\s*\n/);
+    if (firstVersionMatch) {
+      content = content.replace(
+        firstVersionMatch[0], 
+        firstVersionMatch[0] + newVersionHeader + changeEntry
+      );
+    }
+  }
+  
+  // 更新されたコンテンツを書き込む
+  fs.writeFileSync(CHANGELOG_PATH, content);
+  console.log(`CHANGELOG.mdが更新されました: v${version}`);
+}
+
+// メイン処理
+const { type, message } = parseArguments();
+updateChangelog(type, message);


### PR DESCRIPTION
- release.yml: CHANGELOG.mdからリリースノートを抽出し、最近のコミットからもリリースノートを生成するステップを追加
- package.json: changelogスクリプトを追加